### PR TITLE
Improve `as` methods

### DIFF
--- a/.github/assets/badges/interrogate_badge.svg
+++ b/.github/assets/badges/interrogate_badge.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="140" height="20" role="img" aria-label="interrogate: 96.8%">
-    <title>interrogate: 96.8%</title>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="140" height="20" role="img" aria-label="interrogate: 100%">
+    <title>interrogate: 100%</title>
     <linearGradient id="s" x2="0" y2="100%">
         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
         <stop offset="1" stop-opacity=".1"/>
@@ -15,8 +15,8 @@
     <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
         <text aria-hidden="true" x="590" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="610">interrogate</text>
         <text x="590" y="140" transform="scale(.1)" fill="#fff" textLength="610">interrogate</text>
-        <text aria-hidden="true" x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370">96.8%</text>
-        <text x="1160" y="140" transform="scale(.1)" fill="#fff" textLength="370" data-interrogate="result">96.8%</text>
+        <text aria-hidden="true" x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="330">100%</text>
+        <text x="1160" y="140" transform="scale(.1)" fill="#fff" textLength="330" data-interrogate="result">100%</text>
     </g>
     <g id="logo-shadow" transform="matrix(0.854876,0,0,0.854876,-6.73514,1.732)">
         <g transform="matrix(0.299012,0,0,0.299012,9.70229,-6.68582)">

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
-          cache: 'pip'
+          cache: "pip"
           cache-dependency-path: |
             requirements-dev.txt
       - name: Install dependencies
@@ -51,13 +51,14 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
+          cache: "pip"
           cache-dependency-path: |
             requirements-dev.txt
       - name: Install dependencies
         run: |
           pip install -U pip
           pip install -e ".[all,dev]"
+          pip install -U "jax[cpu]"
       - name: Run tests
         run: |
           pytest -vv

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ In a nutshell, using a `Boxes` involve 3 stages:
 | :---: | :--------------------------------------------------------------: | :----------------------------------------------------------------------------------: |
 |   1   | Instantiate a `Boxes` object with one of the `from` classmethods | `from_top_left_corner`, `from_bottom_left_corner`, `from_two_corners`, `from_center` |
 |   2   |        Apply a transformation with a `to` inplace methods        |     `to_top_left_corner`, `to_bottom_left_corner`, `to_two_corners`, `to_center`     |
-|   3   |    Retrieve the modified data with one of the `as` properties    |              `as_dict`, `as_tuple`, `as_array`, `as_numpy`, `as_tensor`              |
+|   3   |    Retrieve the modified data with one of the `as` properties    |      `as_dict`, `as_tuple`, `as_numpy`, `as_array`, `as_tf_tensor`, `as_tensor`      |
 
 <br />
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,7 +131,6 @@ omit = [
   "*examples*",
   "*tests*",
   "src/anyboxes/_version.py",
-  "src/anyboxes/_errors.py",
   "src/anyboxes/implementations/torch/_typing.py",
 ]
 
@@ -145,7 +144,6 @@ omit = [
   "*examples*",
   "*tests*",
   "src/anyboxes/_version.py",
-  "src/anyboxes/_errors.py",
   "src/anyboxes/implementations/torch/_typing.py",
 ]
 exclude_lines = [
@@ -161,4 +159,5 @@ exclude_lines = [
   "except ImportError:",
   "Protocol",
   "@(abc.)?abstractmethod",
+  "ModuleNotFoundError",
 ]

--- a/src/anyboxes/_errors.py
+++ b/src/anyboxes/_errors.py
@@ -1,8 +1,31 @@
 class MissingToMethodError(RuntimeError):
     """An error to handle case where to methods hasn't been called."""
 
-    def str(self):
+    def __str__(self):
+        """Error message to print."""
         return (
-            "One of the method `to_center`, `to_top_left_corner`,"
-            " `to_bottom_left_corner` or `to_two_corners` must be called."
+            "One of the method `to_top_left_corner`, `to_bottom_left_corner`,"
+            " `to_two_corners` or `to_center` must be called."
+        )
+
+
+class OptionalDependencyImportError(ModuleNotFoundError):
+    """An error to handle case where an optional dependency is missing."""
+
+    def __init__(self, dependency: str):
+        """Instantiate a MissingImportError.
+
+        Args:
+            dependency (str): Missing dependency.
+        """
+        self.dependency = dependency
+
+    def __str__(self):
+        """Error message to print."""
+        return (
+            f'The optional dependency "{self.dependency}" is missing, please consider'
+            " to reinstall the project with the command `pip install"
+            f' "anyboxes[{self.dependency}]"`. You may need also to combine it with'
+            " others optional dependencies, you can use the command `pip install"
+            ' "anyboxes[all]". for installing all optional dependencies.'
         )

--- a/src/anyboxes/implementations/torch/coordinates.py
+++ b/src/anyboxes/implementations/torch/coordinates.py
@@ -23,13 +23,13 @@ class Coordinates:
         self.y = y.to(device)
         self.batch_size: int = len(x)
 
-    def to_dict(self) -> dict[str, CoordTensorType]:
+    def to_dict(self) -> dict[str, list[int | float]]:
         """Return x and y as dict.
 
         Returns:
             dict[str, CoordTensorType]: dict containing coordinates tensors.
         """
-        return {"x": self.x, "y": self.y}
+        return {"x": self.x.tolist(), "y": self.y.tolist()}
 
 
 class Size:
@@ -47,10 +47,10 @@ class Size:
         self.h = h.to(device)
         self.batch_size: int = len(w)
 
-    def to_dict(self) -> dict[str, CoordTensorType]:
+    def to_dict(self) -> dict[str, list[int | float]]:
         """Return w and h as dict.
 
         Returns:
             dict[str, CoordTensorType]: dict containing size tensors.
         """
-        return {"w": self.w, "h": self.h}
+        return {"w": self.w.tolist(), "h": self.h.tolist()}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,58 @@
+import jax.numpy as jnp
+import numpy as np
 import pytest
+import tensorflow as tf
 import torch
 
 
 @pytest.fixture
 def top_left_data():
     return [[0.0, 0.0, 3.0, 2.0], [10.0, 10.0, 10.0, 10.0]]
+
+
+@pytest.fixture
+def top_left_dict():
+    return {
+        "1": {"x": [0.0, 10.0], "y": [0.0, 10.0]},
+        "2": {"x": [3.0, 20.0], "y": [0.0, 10.0]},
+        "3": {"x": [3.0, 20.0], "y": [2.0, 20.0]},
+        "4": {"x": [0.0, 10.0], "y": [2.0, 20.0]},
+        "c": {"x": [1.5, 15.0], "y": [1.0, 15.0]},
+        "size": {"w": [3.0, 10.0], "h": [2.0, 10.0]},
+    }
+
+
+@pytest.fixture
+def top_left_tuple():
+    return (
+        [0.0, 10.0],
+        [0.0, 10.0],
+        [3.0, 20.0],
+        [0.0, 10.0],
+        [3.0, 20.0],
+        [2.0, 20.0],
+        [0.0, 10.0],
+        [2.0, 20.0],
+        [1.5, 15.0],
+        [1.0, 15.0],
+        [3.0, 10.0],
+        [2.0, 10.0],
+    )
+
+
+@pytest.fixture
+def top_left_numpy(top_left_data):
+    return np.asarray(top_left_data)
+
+
+@pytest.fixture
+def top_left_array(top_left_data):
+    return jnp.asarray(top_left_data)
+
+
+@pytest.fixture
+def top_left_tf_tensor(top_left_data):
+    return tf.convert_to_tensor(top_left_data)
 
 
 @pytest.fixture

--- a/tests/test_boxes_representations.py
+++ b/tests/test_boxes_representations.py
@@ -1,0 +1,47 @@
+import jax.numpy as jnp
+import numpy as np
+import pytest
+import tensorflow as tf
+import torch
+
+from anyboxes.implementations.torch.boxes import TorchBoxes
+
+
+@pytest.mark.usefixtures("top_left_tensor", "top_left_dict")
+def test_as_dict(top_left_tensor, top_left_dict):
+    b = TorchBoxes.from_top_left_corner(top_left_tensor)
+    assert b.as_dict == top_left_dict
+
+
+@pytest.mark.usefixtures("top_left_tensor", "top_left_tuple")
+def test_as_tuple(top_left_tensor, top_left_tuple):
+    b = TorchBoxes.from_top_left_corner(top_left_tensor)
+    assert b.as_tuple == top_left_tuple
+
+
+@pytest.mark.usefixtures("top_left_tensor", "top_left_numpy")
+def test_as_numpy(top_left_tensor, top_left_numpy):
+    b = TorchBoxes.from_top_left_corner(top_left_tensor)
+    b = b.to_top_left_corner()
+    np.testing.assert_equal(b.as_numpy, top_left_numpy)
+
+
+@pytest.mark.usefixtures("top_left_tensor", "top_left_array")
+def test_as_array(top_left_tensor, top_left_array):
+    b = TorchBoxes.from_top_left_corner(top_left_tensor)
+    b = b.to_top_left_corner()
+    assert jnp.array_equal(b.as_array, top_left_array)
+
+
+@pytest.mark.usefixtures("top_left_tensor", "top_left_tf_tensor")
+def test_as_tf_tensor(top_left_tensor, top_left_tf_tensor):
+    b = TorchBoxes.from_top_left_corner(top_left_tensor)
+    b = b.to_top_left_corner()
+    tf.assert_equal(b.as_tf_tensor, top_left_tf_tensor)
+
+
+@pytest.mark.usefixtures("top_left_tensor")
+def test_as_tensor(top_left_tensor):
+    b = TorchBoxes.from_top_left_corner(top_left_tensor)
+    b = b.to_top_left_corner()
+    assert torch.equal(b.as_tensor, top_left_tensor)

--- a/tests/test_boxes_transformations.py
+++ b/tests/test_boxes_transformations.py
@@ -106,7 +106,7 @@ def test_from_two_corners_to_two_corners(two_corners_tensor):
 
 
 @pytest.mark.usefixtures("center_tensor", "squared_center_tensor")
-def test_from_center_squared_to_center(center_tensor, squared_center_tensor):
+def test_from_center_square_to_squared_center(center_tensor, squared_center_tensor):
     b = TorchBoxes.from_center(center_tensor)
     assert torch.equal(b.square().to_center().as_tensor, squared_center_tensor)
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,56 @@
+import pytest
+
+from anyboxes._errors import MissingToMethodError
+from anyboxes.implementations.torch.boxes import TorchBoxes
+
+
+@pytest.mark.usefixtures("top_left_tensor")
+def test_missing_to_method_as_numpy(top_left_tensor):
+    with pytest.raises(
+        MissingToMethodError,
+        match=(
+            "One of the method `to_top_left_corner`, `to_bottom_left_corner`,"
+            " `to_two_corners` or `to_center` must be called."
+        ),
+    ):
+        b = TorchBoxes.from_top_left_corner(top_left_tensor)
+        b.as_numpy
+
+
+@pytest.mark.usefixtures("top_left_tensor")
+def test_missing_to_method_as_array(top_left_tensor):
+    with pytest.raises(
+        MissingToMethodError,
+        match=(
+            "One of the method `to_top_left_corner`, `to_bottom_left_corner`,"
+            " `to_two_corners` or `to_center` must be called."
+        ),
+    ):
+        b = TorchBoxes.from_top_left_corner(top_left_tensor)
+        b.as_array
+
+
+@pytest.mark.usefixtures("top_left_tensor")
+def test_missing_to_method_as_tf_tensor(top_left_tensor):
+    with pytest.raises(
+        MissingToMethodError,
+        match=(
+            "One of the method `to_top_left_corner`, `to_bottom_left_corner`,"
+            " `to_two_corners` or `to_center` must be called."
+        ),
+    ):
+        b = TorchBoxes.from_top_left_corner(top_left_tensor)
+        b.as_tf_tensor
+
+
+@pytest.mark.usefixtures("top_left_tensor")
+def test_missing_to_method_as_tensor(top_left_tensor):
+    with pytest.raises(
+        MissingToMethodError,
+        match=(
+            "One of the method `to_top_left_corner`, `to_bottom_left_corner`,"
+            " `to_two_corners` or `to_center` must be called."
+        ),
+    ):
+        b = TorchBoxes.from_top_left_corner(top_left_tensor)
+        b.as_tensor


### PR DESCRIPTION
# What does this PR do?

This PR rewrite `as` methods in order to allow to outputs data to every computing frameworks. This implies adding an exception where an framework is missing.

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?
